### PR TITLE
cryptominisat 5.12.1 - rebuild py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/install-lib.sh
+++ b/recipe/install-lib.sh
@@ -7,7 +7,6 @@ popd
 pushd cadiback
     ./configure
     make -j$CPU_COUNT
-    ${AR:-ar} rcs libcadiback.a cadiback.o
 popd
 
 pushd cryptominisat

--- a/recipe/install-lib.sh
+++ b/recipe/install-lib.sh
@@ -7,6 +7,7 @@ popd
 pushd cadiback
     ./configure
     make -j$CPU_COUNT
+    ${AR:-ar} rcs libcadiback.a cadiback.o
 popd
 
 pushd cryptominisat

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,18 +19,19 @@ source:
   # We need to use source from git because
   # https://github.com/arminbiere/cadiback/blob/789329d8fcda851085ed72f1b07d8c3f46243b8a/generate#L7
   - git_url: https://github.com/meelgroup/cadiback.git
-    git_rev: mate
+    # OLD API commit (cryptominisat version update will require update this git_rev as well)
+    git_rev: ea65a9442fc2604ee5f4ffd0f0fdd0bf481d5b42
     folder: cadiback
     patches:
      - patches/fix_cadiback.patch
   # The reason why cadical should be built from source here:
   # https://github.com/arminbiere/cadiback/blob/789329d8fcda851085ed72f1b07d8c3f46243b8a/README.md?plain=1#L7
   - git_url: https://github.com/meelgroup/cadical.git
-    git_rev: mate-only-libraries-1.8.0
+    git_rev: 16dde5487287b349d19eb9f16642a797e38ca34f
     folder: cadical
 
 build:
-  number: 0
+  number: 1
   # After adding cadical and caiback as dependency to this package it cannot be build for windows
   # https://github.com/msoos/cryptominisat/commit/d1a51c9e7a96206bb2ddd07ae524e147b796e4b2
   skip: True  # [win]


### PR DESCRIPTION
cryptominisat 5.12.1

Destination channel: Defaults

Links
[PKG-10020](https://anaconda.atlassian.net/browse/PKG-10020)
dev_url: https://github.com/msoos/cryptominisat/tree/5.12.1
conda_forge: https://github.com/conda-forge/cryptominisat-feedstock
pypi: none

Explanation of changes:

- rebuild py314

[PKG-10020]: https://anaconda.atlassian.net/browse/PKG-10020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ